### PR TITLE
feat(client): 支持缓存token统计和成本计算优化

### DIFF
--- a/tests/test_json_response.py
+++ b/tests/test_json_response.py
@@ -33,6 +33,7 @@ def test_json_response_response_api():
     )
     print(result)
     print(client.cost)
+    print(client.token_usage_total)
     assert isinstance(result, MathReasoning)
 
 
@@ -57,14 +58,16 @@ You must answer in JSON format like:
     ]
     result = client.get_json_response(
         messages=messages,
-        model="doubao-seed-1.6",
+        model="deepseek",
         output_type=MathReasoning,
         extra_body={"thinking": {"type": "disabled"}},
         use_response=False,
     )
     print(result)
+    print(client.cost)
+    print(client.token_usage_total)
     assert isinstance(result, MathReasoning)
 
 
 if __name__ == "__main__":
-    test_json_response_response_api()
+    test_json_response_response_completion()


### PR DESCRIPTION
- 在token使用统计中新增cached_tokens字段
- 优化_update_total_token_usage方法，统一处理CompletionUsage和ResponseUsage两种类型
- 将cached_tokens从prompt_tokens中分离单独统计
- 在成本计算中加入input_cost_cache_hit参数支持缓存token计费
- 消除CompletionUsage和ResponseUsage处理逻辑的重复代码
Close #1 